### PR TITLE
feat(print-logfile): Print path to logfile on error

### DIFF
--- a/lib/validate-commit-msg.js
+++ b/lib/validate-commit-msg.js
@@ -30,11 +30,15 @@ var TYPES = {
   revert: true
 };
 
+var commitMsgFile = process.argv[2];
+var incorrectLogFile = commitMsgFile.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs');
+
 var error = function() {
   // gitx does not display it
   // http://gitx.lighthouseapp.com/projects/17830/tickets/294-feature-display-hook-error-message-when-hook-fails
   // https://groups.google.com/group/gitx/browse_thread/thread/a03bcab60844b812
-  console.error('INVALID COMMIT MSG: ' + util.format.apply(null, arguments));
+  console.error('INVALID COMMIT MSG: ' + util.format.apply(null, arguments)
+    + ' (log: ' + incorrectLogFile + ')');
 };
 
 var validateMessage = function(message) {
@@ -84,9 +88,6 @@ var firstLineFromBuffer = function(buffer) {
 
 // publish for testing
 exports.validateMessage = validateMessage;
-
-var commitMsgFile = process.argv[2];
-var incorrectLogFile = commitMsgFile.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs');
 
 fs.readFile(
   commitMsgFile, function(err, buffer) {


### PR DESCRIPTION
I was preparing a commit in a project
(https://github.com/mineral-ui/mineral-ui) that uses validate-commit-msg
and the post-commit hook failed. At first, I thought my commit message
was lost (it was a long one, so I was quite frustrated). After digging
through the internals of the project I found that the commit message
was in fact logged to .git/logs/incorrect-commit-msgs.

To help others who might end up in the same situation, I'm adding the
log path to the error message.