### PR TITLE
feat(): add ci commit type

### DIFF
--- a/lib/validate-commit-msg.js
+++ b/lib/validate-commit-msg.js
@@ -27,7 +27,8 @@ var TYPES = {
   perf: true,
   test: true,
   chore: true,
-  revert: true
+  revert: true,
+  ci: true
 };
 
 var error = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validate-commit-message",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": "Frederik Krautwald",
   "description": "GIT COMMIT-MSG hook for validating commit message.",
   "license": "Unlicense",


### PR DESCRIPTION
Commitizen has `ci` as one of the default options. It'd be great to be able to use this tool and have it support all of the options of commitizen.